### PR TITLE
Cleanup and format; move helper functions into utils.

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1,14 +1,19 @@
 """A collection of utilities for DCGAN training, testing, and validation."""
 
 import os
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import constants
 
+import matplotlib.pyplot as plt
+import numpy as np
 import torch
 import torch.nn as nn
 import torchvision.datasets as dset
 import torchvision.transforms as transforms
+import torchvision.utils as vutils
+
+from numpy.random import choice
 
 # Constants #
 
@@ -94,3 +99,71 @@ def data_synthesis(
         )
         datasets.append(dataset)
     return torch.utils.data.ConcatDataset(datasets)
+
+def add_label_noise(y: torch.Tensor, p_flip: float):
+    """Flips binary labels with some probability `p_flip`."""
+    n_select = int(p_flip * y.shape[0])
+    flip_ix = choice([i for i in range(y.shape[0])], size=n_select)
+    y[flip_ix] = 1 - y[flip_ix]
+
+def plot_results(**kwargs: Any):
+    """Plots a batch of real and fake images along with loss metrics.
+
+    Args:
+        **kwargs: A key/value mapping of the following:
+            * device: The torch.device to run render with.
+            * dataloader: The torch.utils.data.DataLoader used.
+            * G_losses: A list of Generator losses from each iteration.
+            * D_losses: A list of Discriminator losses from each iteration.
+            * img_list: A list of fake images.
+            * name: A string name for the resulting plots.
+            * outdir: The directory to save images to.
+    """
+    # Initialize parameters
+    device = kwargs['device']
+    dataloader = kwargs['dataloader']
+    G_losses = kwargs['G_losses']
+    D_losses = kwargs['D_losses']
+    img_list = kwargs['img_list']
+    name = kwargs['name']
+    outdir = kwargs['outdir']
+
+    plt.figure(figsize=(10,5))
+    plt.title('Generator and Discriminator Loss During Training')
+    plt.plot(G_losses,label='G')
+    plt.plot(D_losses,label='D')
+    plt.xlabel('iterations')
+    plt.ylabel('Loss')
+    plt.legend()
+
+    # Save loss graph
+    plt.savefig(os.path.join(outdir, f'{name}_gd_loss.png'), format='png')
+
+    # Grab a batch of real images from the dataloader
+    real_batch = next(iter(dataloader))
+
+    # Plot the real images
+    plt.figure(figsize=(15,15))
+    plt.subplot(1,2,1)
+    plt.axis('off')
+    plt.title('Real Images')
+    plt.imshow(
+        np.transpose(
+            vutils.make_grid(
+                real_batch[0].to(device)[:64],
+                padding=5,
+                normalize=True
+            ).cpu(),
+            (1,2,0),
+        ),
+    )
+
+    # Plot the fake images from the last epoch
+    plt.subplot(1,2,2)
+    plt.axis('off')
+    plt.title('Fake Images')
+    plt.imshow(np.transpose(img_list[-1],(1,2,0)))
+
+    # Save real/fake comparison
+    plt.savefig(
+        os.path.join(outdir, f'{name}_real_fake_comparison.png'), format='png')


### PR DESCRIPTION
* Modify signature of noisy_labels to indicate that it passes y by
reference; no need to return a value here
* Add type annotations to add_noise(...)
* Move add_noise(...) into the utils module
* Move plot_results(...) into the utils module
* Remove the 'headless' parameter, we have no need to modally show
visualizations at the end of a run
* Add named constants where necessary to remove "magic numbers"

Closes #21 